### PR TITLE
Add Netlify redirects for JS imports

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,27 @@
 [build]
   command = "npm run build:netlify"
   publish = "public"
+
+[[redirects]]
+  from = "/js/config"
+  to = "/js/config.js"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/js/games"
+  to = "/js/games.js"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/js/games/Game"
+  to = "/js/games/Game.js"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/js/games/Games"
+  to = "/js/games/Games.js"
+  status = 200
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build:netlify"
   publish = "public"
 
+# Netlify Rewrites
+# https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
+# https://docs.netlify.com/routing/redirects/rewrites-proxies
 [[redirects]]
   from = "/js/config"
   to = "/js/config.js"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:mjs": "npx snowpack && npx tsc",
     "build:bundle": "npx snowpack --nomodule public/js/game-bug.js && shx cp -r web_modules public",
     "build:end-user": "npx symlink-cli game-bug.html public/index.html",
-    "build:netlify": "rm public/index.html && cp game-bug.html public/index.html",
+    "build:netlify": "rm public/index.html && cp game-bug.html public/index.html && ls -al public && ls -al public/js && ls -al public/web_modules",
     "start": "npx serve --symlinks -n -d -c serve.json"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build:mjs": "npx snowpack && npx tsc",
     "build:bundle": "npx snowpack --nomodule public/js/game-bug.js && shx cp -r web_modules public",
     "build:end-user": "npx symlink-cli game-bug.html public/index.html",
-    "build:netlify": "npm run build && rm public/index.html && cp game-bug.html public/index.html && ls -al public && ls -al public/js && ls -al public/web_modules",
+    "build:netlify": "npm run build && rm public/index.html && cp game-bug.html public/index.html",
+    "build:netlify:debug": "ls -al public && ls -al public/js && ls -al public/web_modules",
     "start": "npx serve --symlinks -n -d -c serve.json"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:mjs": "npx snowpack && npx tsc",
     "build:bundle": "npx snowpack --nomodule public/js/game-bug.js && shx cp -r web_modules public",
     "build:end-user": "npx symlink-cli game-bug.html public/index.html",
-    "build:netlify": "rm public/index.html && cp game-bug.html public/index.html && ls -al public && ls -al public/js && ls -al public/web_modules",
+    "build:netlify": "npm run build && rm public/index.html && cp game-bug.html public/index.html && ls -al public && ls -al public/js && ls -al public/web_modules",
     "start": "npx serve --symlinks -n -d -c serve.json"
   },
   "repository": {


### PR DESCRIPTION
Adding more housekeeping to setup redirects for JS modules in the browser.

See #2.